### PR TITLE
[MVP3] Custom Matrix chat client UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Next.js frontend for LifeOS with responsive module-driven UX.
 - Notifications Center
 
 Inventory includes food-specific recipe CRUD, feasibility checks, and quick-add actions for missing ingredients.
+Matrix includes a LifeOS-oriented chat shell (rooms, timeline, composer, unread signals, and context quick actions).
 
 ## Quick Start
 ```bash

--- a/docs/CODEX_HANDOFF_LOG.md
+++ b/docs/CODEX_HANDOFF_LOG.md
@@ -160,3 +160,31 @@
 ### Next steps
 - Integrate `GET /api/matrix/session` into matrix client boot flow in UI.
 - Add server-side bridge token verification path for matrix mutation APIs.
+
+## 2026-02-17 (MVP3 custom matrix client UI)
+### What changed
+- Extended `app/page.tsx` with a new `chat` app view and dashboard launcher card.
+- Implemented Matrix client shell UX:
+  - room list with unread badges and explicit sync action
+  - timeline panel with composer and send states (`sending/sent/failed`)
+  - progressive disclosure of bridge details in an advanced panel
+- Added contextual quick actions to inject workflow context directly into chat composer:
+  - share active task
+  - share food context
+  - share daily focus
+- Wired chat initialization to `GET /api/matrix/session` only when chat view opens (event-driven load; no polling loops).
+- Added room-read behavior that explicitly clears unread signal and emits relay update hook.
+- Updated `README.md` and `docs/CODEX_MEMORY.md` for matrix UI behavior.
+
+### Why
+- Execute MVP3 chat UI scope with a LifeOS-native workflow surface instead of a generic clone, while keeping core chat path simple and explicit.
+
+### Commands/tests run
+- `./node_modules/.bin/tsc --noEmit && npm run test && npm run build`
+
+### Known issues/risks
+- Timeline currently uses local optimistic state and relay hooks; historical message backfill API is not yet exposed.
+
+### Next steps
+- Connect timeline read model to backend event history endpoint when available.
+- Add mobile-optimized composer affordances and keyboard shortcuts for desktop power flow.

--- a/docs/CODEX_MEMORY.md
+++ b/docs/CODEX_MEMORY.md
@@ -12,6 +12,7 @@
 - Added recipe CRUD UX with inline validation, ingredient normalization hints (unit aliases), and explicit correction feedback before save.
 - Added session profile route (`/api/session/profile`) and client-side profile consumption.
 - Added matrix session bridge route (`/api/matrix/session`) with explicit session failure states and short-lived bridge token issuance.
+- Added Matrix client shell in dashboard app: room list, timeline composer, unread badges, and contextual quick actions from task/inventory focus.
 
 ## Key files
 - `app/page.tsx`
@@ -19,6 +20,7 @@
 - `app/api/lifeos/[...path]/route.ts`
 - `app/api/session/profile/route.ts`
 - `app/api/matrix/session/route.ts`
+- `lib/matrix-bridge.ts`
 - `app/api/local-auth/*`
 
 ## Operational notes


### PR DESCRIPTION
## Summary
- add a new Matrix app view in dashboard with rooms, unread badges, timeline, and composer
- add contextual quick actions to chat from task/inventory/focus context
- keep chat loading event-driven via explicit matrix session bootstrap (no polling)

## Validation
- ./node_modules/.bin/tsc --noEmit && npm run test && npm run build

Closes #5
